### PR TITLE
Add testing with chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,17 @@ jdk:
   - openjdk8
   - openjdk11
 
+env:
+  - PROFILES=headless-mode
+  - PROFILES=headless-mode,chrome
+
 before_install:
-  - sudo apt-get -y install chromium-chromedriver firefox-geckodriver
+  - sudo apt-get -y install firefox-geckodriver
 
 script:
-  - ln -s /usr/bin/chromedriver chromedriver && ln -s /usr/bin/geckodriver geckodriver
-  - mvn -B -V clean install -Pheadless-mode
+  - ln -s /usr/bin/geckodriver geckodriver
+  - source .travis/install-chromedriver.sh
+  - mvn -B -V clean install -P${PROFILES}
 
 addons:
   apt:

--- a/.travis/install-chromedriver.sh
+++ b/.travis/install-chromedriver.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euf
+
+LATEST_CHROME_VERSION="`google-chrome-stable --version | sed -E 's/(^Google Chrome |\.[0-9]+ )//g'`"
+LATEST_CHROMEDRIVER_VERSION="`curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE`"
+CHROMEDRIVER_FILENAME="chromedriver_linux64.zip"
+
+printf "LATEST_CHROME_VERSION=%s\nLATEST_CHROMEDRIVER_VERSION=%s\n" "${LATEST_CHROME_VERSION}" "${LATEST_CHROMEDRIVER_VERSION}"
+
+curl -sOL "https://chromedriver.storage.googleapis.com/${LATEST_CHROMEDRIVER_VERSION}/${CHROMEDRIVER_FILENAME}"
+unzip -o "${CHROMEDRIVER_FILENAME}"
+
+set +euf

--- a/.travis/install-maven.sh
+++ b/.travis/install-maven.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euf
+
+MAVEN_BASE_URL=https://archive.apache.org/dist/maven/maven-3/
+MAVEN_VERSION=3.6.3
+MAVEN_SHA=26ad91d751b3a9a53087aefa743f4e16a17741d3915b219cf74112bf87a438c5
+
+sudo apt-get update
+sudo apt-get install -y curl
+sudo mkdir -p /usr/share/maven /usr/share/maven/ref
+sudo curl -fsSL -o /tmp/apache-maven.tar.gz ${MAVEN_BASE_URL}/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
+echo "${MAVEN_SHA} /tmp/apache-maven.tar.gz" | sha256sum -c -
+sudo tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1
+sudo rm -f /tmp/apache-maven.tar.gz
+sudo ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+mvn -version
+
+set +euf

--- a/.travis/install-zulu.sh
+++ b/.travis/install-zulu.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euf
+
+AZUL_GPG_KEY=0xB1998361219BD9C9
+ZULU_VERSION=11
+ZULU_RELEASE=11.37+17
+JAVA_HOME=/usr/lib/jvm/zulu-11-amd64
+
+sudo apt-get update
+sudo apt-get install -y gnupg2 locales
+sudo locale-gen en_US.UTF-8
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys ${AZUL_GPG_KEY}
+echo "deb http://repos.azulsystems.com/ubuntu stable main" | sudo tee -a /etc/apt/sources.list.d/zulu.list
+sudo apt-get update
+sudo apt-get install -y zulu-${ZULU_VERSION}=${ZULU_RELEASE}
+export ALTERNATIVES_JAVA=$(realpath /etc/alternatives/java)
+export JAVA_HOME=${ALTERNATIVES_JAVA%/bin/java}
+export PATH=$JAVA_HOME/bin:$PATH
+java -version
+
+set +euf

--- a/README.md
+++ b/README.md
@@ -3,25 +3,53 @@
 [![Stackoverflow](https://img.shields.io/badge/StackOverflow-primefaces-chocolate.svg)](https://stackoverflow.com/questions/tagged/primefaces-extensions)
 
 PrimeFaces Integration Tests
-==========================
+----------------------------
 
 To provide an integration and regression test suite for PrimeFaces.
 
-### Prerequisites
+## Prerequisites
 
 This project uses [selenium webdriver](https://www.selenium.dev/) for web browser automation.  Currently, a native
-installation of [Firefox](https://firefox.com/) is required, along with the
-[selenium gecko webdriver](https://github.com/mozilla/geckodriver) binary.
+installation of [Firefox](https://firefox.com/) and/or [Chrome](https://www.google.com/chrome/) is required.
+Additionally, the selenium driver corresponding to the browser(s) must also be installed.  These can be downloaded
+from the following locations:
 
-### Build & Run
-- Build by source `mvn clean package`
-- Run "integration tests" `mvn verify`
-  - By default, the webdriver binary is loaded from the base directory of the project with an assumed file name of
-      "geckodriver" for Linux/MacOS and geckdriver.exe for Windows.  A non-default path can be specified via a system
-      property:
+- [selenium gecko webdriver](https://github.com/mozilla/geckodriver)
+- [select chrome webdriver](https://chromedriver.chromium.org/)
 
-      ```mvn verify -Dwebdriver.firefoxDriverBinary=$HOME/.selenium/drivers/firefox/geckdriver```
-  - By default, the tests will be run in a visible browser, but can be run in headless mode by activating the
-  headless-mode profile:
+## Build & Run
+- Build by source: `mvn clean package`
+- Run "integration tests" with the _verify_ phase: `mvn verify`
 
-      ```mvn verify -Pheadless-mode```  
+### Firefox (default)
+
+The default configuration of the project runs tests with a visible Firefox browser.  This requires geckodriver in order
+to allow selenium to control the browser.  This is a binary file that can be downloaded via the link above, and can be
+placed in the base directory of the project where it will be accessed by selenium for running the tests.  The default
+location for the binary is the base directory of the project with an assumed file name of `geckodriver`
+for Linux/MacOS and `geckodriver.exe` for Windows, but a non-default path can be specified via a system property:
+
+    mvn verify -Dwebdriver.firefoxDriverBinary=$HOME/.selenium/drivers/firefox/geckodriver
+  
+The tests will be run by default in a visible browser UI, but can be run in headless mode by activating the
+headless-mode maven profile:
+
+    mvn verify -Pheadless-mode
+      
+### Chrome
+
+Google Chrome may also be used to run the tests by activating the "chrome" maven profile.  This can be done on the
+commandline with the -P maven parameter:
+ 
+    mvn verify -Pchrome
+  
+Using chrome to run the tests requires the "chromedriver" binary which can be downloaded via the link above, and can be
+placed in the base directory of the project.  Selenium will access the binary from the base directory with an assumed
+file name of `chromedriver` for Linux/MacOS and `geckodriver.exe` for Windows, but a non-default path can be specified
+via a system property:
+ 
+      mvn verify -Dwebdriver.chromeDriverBinary=$HOME/.selenium/drivers/chrome/chromedriver -Pchrome
+
+When using chrome, the headless-mode maven profile may be activated to run chrome in headless mode:
+
+     mvn verify -Pchrome,headless-mode

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
     <name>primefaces-integration-tests</name>
 
     <properties>
+        <primefaces-selenium.adapter>org.primefaces.extensions.integrationtests.PrimeFacesSeleniumTomEEFirefoxAdapterImpl</primefaces-selenium.adapter>
+        <webdriver.chromeDriverBinary>chromedriver</webdriver.chromeDriverBinary>
         <webdriver.firefoxDriverBinary>geckodriver</webdriver.firefoxDriverBinary>
         <webdriver.headless>false</webdriver.headless>
         <!-- build configuration -->
@@ -96,6 +98,15 @@
 
     <build>
         <finalName>primefaces-integration-tests</finalName>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>src/test/resources-filtered</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -132,6 +143,7 @@
                         <include>**/*Test</include>
                     </includes>
                     <systemPropertyVariables>
+                        <webdriver.chrome.driver>${webdriver.chromeDriverBinary}</webdriver.chrome.driver>
                         <webdriver.gecko.driver>${webdriver.firefoxDriverBinary}</webdriver.gecko.driver>
                         <webdriver.headless>${webdriver.headless}</webdriver.headless>
                     </systemPropertyVariables>
@@ -156,6 +168,13 @@
                 <webdriver.headless>true</webdriver.headless>
             </properties>
         </profile>
+        <!-- Test with chrome instead of firefox -->
+        <profile>
+            <id>chrome</id>
+            <properties>
+                <primefaces-selenium.adapter>org.primefaces.extensions.integrationtests.PrimeFacesSeleniumTomEEChromeAdapterImpl</primefaces-selenium.adapter>
+            </properties>
+        </profile>
         <!-- Detect windows and set properties accordingly -->
         <profile>
             <id>windows-webdriver-binary</id>
@@ -165,6 +184,7 @@
                 </os>
             </activation>
             <properties>
+                <webdriver.chromeDriverBinary>chromedriver.exe</webdriver.chromeDriverBinary>
                 <webdriver.firefoxDriverBinary>geckodriver.exe</webdriver.firefoxDriverBinary>
             </properties>
         </profile>

--- a/src/test/java/org/primefaces/extensions/integrationtests/PrimeFacesSeleniumTomEEAdapter.java
+++ b/src/test/java/org/primefaces/extensions/integrationtests/PrimeFacesSeleniumTomEEAdapter.java
@@ -17,10 +17,7 @@ package org.primefaces.extensions.integrationtests;
 
 import org.apache.tomee.embedded.Configuration;
 import org.apache.tomee.embedded.Container;
-import org.openqa.selenium.PageLoadStrategy;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
 import org.primefaces.extensions.selenium.spi.PrimeSeleniumAdapter;
 
 import java.io.File;
@@ -29,26 +26,17 @@ import java.net.URL;
 import java.util.Properties;
 import java.util.Random;
 
-public class PrimeFacesSeleniumAdapterImpl implements PrimeSeleniumAdapter
+public abstract class PrimeFacesSeleniumTomEEAdapter implements PrimeSeleniumAdapter
 {
+
+    protected static final String HEADLESS_MODE_SYSPROP_NAME = "webdriver.headless";
+
+    protected static final String HEADLESS_MODE_SYSPROP_VAL_DEFAULT = "false";
+
     private Container container;
 
-    private static final String HEADLESS_MODE_SYSPROP_NAME = "webdriver.headless";
-
-    private static final String HEADLESS_MODE_SYSPROP_VAL_DEFAULT = "false";
-
     @Override
-    public WebDriver createWebDriver()
-    {
-        FirefoxOptions options = new FirefoxOptions();
-        options.setPageLoadStrategy(PageLoadStrategy.NORMAL);
-        options.setHeadless(
-                Boolean.parseBoolean(
-                        System.getProperty(HEADLESS_MODE_SYSPROP_NAME, HEADLESS_MODE_SYSPROP_VAL_DEFAULT)
-                )
-        );
-        return new FirefoxDriver(options);
-    }
+    public abstract WebDriver createWebDriver();
 
     @Override
     public void startup() throws Exception
@@ -112,4 +100,5 @@ public class PrimeFacesSeleniumAdapterImpl implements PrimeSeleniumAdapter
     {
         return container;
     }
+
 }

--- a/src/test/java/org/primefaces/extensions/integrationtests/PrimeFacesSeleniumTomEEChromeAdapterImpl.java
+++ b/src/test/java/org/primefaces/extensions/integrationtests/PrimeFacesSeleniumTomEEChromeAdapterImpl.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2011-2020 PrimeFaces Extensions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.primefaces.extensions.integrationtests;
+
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.primefaces.extensions.selenium.spi.PrimeSeleniumAdapter;
+
+
+public class PrimeFacesSeleniumTomEEChromeAdapterImpl extends PrimeFacesSeleniumTomEEAdapter implements PrimeSeleniumAdapter {
+
+    @Override
+    public WebDriver createWebDriver()
+    {
+        ChromeOptions chromeOptions = new ChromeOptions();
+        chromeOptions.setPageLoadStrategy(PageLoadStrategy.NORMAL);
+        chromeOptions.setHeadless(
+                Boolean.parseBoolean(
+                        System.getProperty(HEADLESS_MODE_SYSPROP_NAME, HEADLESS_MODE_SYSPROP_VAL_DEFAULT)
+                )
+        );
+        return new ChromeDriver(chromeOptions);
+    }
+
+}

--- a/src/test/java/org/primefaces/extensions/integrationtests/PrimeFacesSeleniumTomEEFirefoxAdapterImpl.java
+++ b/src/test/java/org/primefaces/extensions/integrationtests/PrimeFacesSeleniumTomEEFirefoxAdapterImpl.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2011-2020 PrimeFaces Extensions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.primefaces.extensions.integrationtests;
+
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.primefaces.extensions.selenium.spi.PrimeSeleniumAdapter;
+
+public class PrimeFacesSeleniumTomEEFirefoxAdapterImpl extends PrimeFacesSeleniumTomEEAdapter implements PrimeSeleniumAdapter {
+
+    private static final String HEADLESS_MODE_SYSPROP_NAME = "webdriver.headless";
+
+    private static final String HEADLESS_MODE_SYSPROP_VAL_DEFAULT = "false";
+
+    @Override
+    public WebDriver createWebDriver()
+    {
+        FirefoxOptions options = new FirefoxOptions();
+        options.setPageLoadStrategy(PageLoadStrategy.NORMAL);
+        options.setHeadless(
+                Boolean.parseBoolean(
+                        System.getProperty(HEADLESS_MODE_SYSPROP_NAME, HEADLESS_MODE_SYSPROP_VAL_DEFAULT)
+                )
+        );
+        return new FirefoxDriver(options);
+    }
+
+}

--- a/src/test/resources-filtered/primefaces-selenium/config.properties
+++ b/src/test/resources-filtered/primefaces-selenium/config.properties
@@ -1,0 +1,1 @@
+adapter=${primefaces-selenium.adapter}

--- a/src/test/resources/primefaces-selenium/config.properties
+++ b/src/test/resources/primefaces-selenium/config.properties
@@ -1,1 +1,0 @@
-adapter=org.primefaces.extensions.integrationtests.PrimeFacesSeleniumAdapterImpl


### PR DESCRIPTION
- Refactored primefaces selenium adapter to be a base class extended by chrome/firefox variants and
  specified via a system property to a filtered config.properties maven test resource
- Added maven properties to specify primefaces selenium adapter implementation and chrome driver binary
  along with a maven profile to allow overriding the adapter implementation property for chrome
- Added chrome job to travis
- Updated README.md to add chrome notes