### PR TITLE
DataTable; filter-event and issue 7026

### DIFF
--- a/src/main/java/org/primefaces/extensions/integrationtests/datatable/DataTable009.java
+++ b/src/main/java/org/primefaces/extensions/integrationtests/datatable/DataTable009.java
@@ -81,6 +81,15 @@ public class DataTable009 implements Serializable {
         TestUtils.addMessage("FilteredValue(s)", filterValuesFlat);
     }
 
+    public void reportFilteredProgLanguages() {
+        String filterValuesFlat = "null";
+        if (filteredProgLanguages != null) {
+            filterValuesFlat = filteredProgLanguages.stream().map(ProgrammingLanguage::getName).collect(Collectors.joining(","));
+        }
+
+        TestUtils.addMessage("FilteredValue(s)", filterValuesFlat);
+    }
+
     public List<Integer> firstAppearedYearsWithProgLanguages() {
         return progLanguages.stream().map(p -> p.getFirstAppeared()).distinct().sorted().collect(Collectors.toList());
     }

--- a/src/main/webapp/datatable/dataTable009.xhtml
+++ b/src/main/webapp/datatable/dataTable009.xhtml
@@ -41,7 +41,7 @@
                 </p:column>
             </p:dataTable>
 
-            <p:commandButton id="button" value="Submit" update="@form"/>
+            <p:commandButton id="buttonReportFilteredProgLanguages" value="report filtered ProgLanguages" update="@form" action="#{dataTable009.reportFilteredProgLanguages}"/>
         </h:form>
 
     </h:body>


### PR DESCRIPTION
@Rapster, @melloware, @tandraschko: For DataTable009Test#testFilterIssue1390 and DataTable009Test#testKeepSelectOneMenuFilter i would need your input regarding which behaviour is the correct one we should test.

> Is <p:ajax event="filter" executed before or after the filter is applied?
> Until @Rapster´s modification a few days ago it was something like "afterFilter", now it´s "beforeFilter". Rapster moved some code within FilterFeature from decode to encode. This explains this behaviour-change.
> When i look into primefaces/primefaces#1390 it sounds like some time ago "filter" was a "beforeFilter".
> What is the correct behaviour? --> The behaviour we should test and the behaviour we should write into our documentation. Currently i believe it should be "beforeFilter" and we should modify DataTable009 - tests which only worked for some time because "filter" behaved only temporarily during PF10-development like "afterFilter".