### PR TITLE
DataTable: selection - single - unselect; https://github.com/primefaces/primefaces/issues/7128

### DIFF
--- a/src/main/java/org/primefaces/extensions/integrationtests/datatable/DataTable004.java
+++ b/src/main/java/org/primefaces/extensions/integrationtests/datatable/DataTable004.java
@@ -24,10 +24,9 @@ package org.primefaces.extensions.integrationtests.datatable;
 import lombok.Data;
 import org.primefaces.event.SelectEvent;
 import org.primefaces.event.UnselectEvent;
+import org.primefaces.extensions.integrationtests.general.utilities.TestUtils;
 
 import javax.annotation.PostConstruct;
-import javax.faces.application.FacesMessage;
-import javax.faces.context.FacesContext;
 import javax.faces.view.ViewScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -53,19 +52,19 @@ public class DataTable004 implements Serializable {
     }
 
     public void onRowSelect(SelectEvent<ProgrammingLanguage> event) {
-        FacesMessage msg = new FacesMessage("ProgrammingLanguage Selected", event.getObject().getId() + " - " + event.getObject().getName());
-        FacesContext.getCurrentInstance().addMessage(null, msg);
+        TestUtils.addMessage("ProgrammingLanguage Selected", event.getObject().getId() + " - " + event.getObject().getName());
     }
 
     public void onRowUnselect(UnselectEvent<ProgrammingLanguage> event) {
-        FacesMessage msg = new FacesMessage("ProgrammingLanguage Unselected", event.getObject().getId() + " - " + event.getObject().getName());
-        FacesContext.getCurrentInstance().addMessage(null, msg);
+        TestUtils.addMessage("ProgrammingLanguage Unselected", event.getObject().getId() + " - " + event.getObject().getName());
     }
 
     public void submit() {
         if (selectedProgLanguage != null) {
-            FacesMessage msg = new FacesMessage("Selected ProgrammingLanguage", selectedProgLanguage.getId() + " - " + selectedProgLanguage.getName());
-            FacesContext.getCurrentInstance().addMessage(null, msg);
+            TestUtils.addMessage("Selected ProgrammingLanguage", selectedProgLanguage.getId() + " - " + selectedProgLanguage.getName());
+        }
+        else {
+            TestUtils.addMessage("no ProgrammingLanguage selected", "");
         }
     }
 }

--- a/src/main/webapp/datatable/dataTable004.xhtml
+++ b/src/main/webapp/datatable/dataTable004.xhtml
@@ -34,6 +34,7 @@
             </p:dataTable>
 
             <p:commandButton id="button" value="Submit" update="@form" action="#{dataTable004.submit}"/>
+            <p:commandButton id="buttonMsgOnly" value="Submit - update messages only" process="form:datatable" action="#{dataTable004.submit}"/>
         </h:form>
 
     </h:body>

--- a/src/main/webapp/datatable/dataTable004.xhtml
+++ b/src/main/webapp/datatable/dataTable004.xhtml
@@ -6,7 +6,11 @@
 
 <f:view contentType="text/html;charset=UTF-8" encoding="UTF-8">
     <h:head>
-
+        <style type="text/css">
+            body {
+                background-color: #f8f9fa;
+            }
+        </style>
     </h:head>
 
     <h:body>
@@ -34,7 +38,19 @@
             </p:dataTable>
 
             <p:commandButton id="button" value="Submit" update="@form" action="#{dataTable004.submit}"/>
-            <p:commandButton id="buttonMsgOnly" value="Submit - update messages only" process="form:datatable" action="#{dataTable004.submit}"/>
+            <p:commandButton id="buttonMsgOnly" value="Submit - update card only" process="form:datatable" update="form:card"/>
+
+            <p:card id="card" style="width: 25rem; margin-top: 2em">
+                <f:facet name="title">
+                    selected programming language
+                </f:facet>
+                <p:outputPanel rendered="#{not empty dataTable004.selectedProgLanguage}">
+                    #{dataTable004.selectedProgLanguage.name}
+                </p:outputPanel>
+                <p:outputPanel rendered="#{empty dataTable004.selectedProgLanguage}">
+                    no ProgrammingLanguage selected
+                </p:outputPanel>
+            </p:card>
         </h:form>
 
     </h:body>

--- a/src/test/java/org/primefaces/extensions/integrationtests/datatable/DataTable004Test.java
+++ b/src/test/java/org/primefaces/extensions/integrationtests/datatable/DataTable004Test.java
@@ -26,7 +26,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Action;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
@@ -40,7 +42,7 @@ public class DataTable004Test extends AbstractDataTableTest {
 
     @Test
     @Order(1)
-    @DisplayName("DataTable: selection - single; click on row & events; including https://github.com/primefaces/primefaces/issues/7128")
+    @DisplayName("DataTable: selection - single; click on row & events")
     public void testSelectionSingle(Page page) {
         // Arrange
         DataTable dataTable = page.dataTable;
@@ -75,13 +77,40 @@ public class DataTable004Test extends AbstractDataTableTest {
         asssertMessage(page, "ProgrammingLanguage Unselected", languages.get(4).getName());
 
         // Act
+        page.button.click();
+
+        // Assert (no row selected)
+        dataTable.getRows().forEach(r -> Assertions.assertEquals("false", r.getWebElement().getAttribute("aria-selected")));
+        asssertMessage(page, "no ProgrammingLanguage selected", "");
+        assertConfiguration(dataTable.getWidgetConfiguration());
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("DataTable: selection - single - unselect; https://github.com/primefaces/primefaces/issues/7128")
+    public void testSelectionSingleUnselect(Page page) {
+        // Arrange
+        DataTable dataTable = page.dataTable;
+        Assertions.assertNotNull(dataTable);
+
+        // Act
+        dataTable.getCell(2, 0).getWebElement().click();
+        page.buttonMsgOnly.click();
+
+        // Assert
+        WebElement card = page.getWebDriver().findElement(By.id("form:card"));
+        Assertions.assertTrue(card.getText().contains(languages.get(2).getName()));
+
+        // Act - unselect row
+        Actions actions = new Actions(page.getWebDriver());
+        actions.keyDown(Keys.META).click(dataTable.getCell(2, 0).getWebElement()).keyUp(Keys.META).perform();
         page.buttonMsgOnly.click();
 
         // Assert (no row selected)
         dataTable.getRows().forEach(r -> Assertions.assertEquals("false", r.getWebElement().getAttribute("aria-selected")));
-        Assertions.assertEquals(0, page.messages.getAllMessages().size());
+        card = page.getWebDriver().findElement(By.id("form:card"));
+        Assertions.assertTrue(card.getText().contains("no ProgrammingLanguage selected"));
         assertConfiguration(dataTable.getWidgetConfiguration());
-
     }
 
     private void asssertMessage(Page page, String summary, String detail) {


### PR DESCRIPTION
@Rapster : tried to do a integration-test for https://github.com/primefaces/primefaces/issues/7128

The weird thing is it already worked before https://github.com/primefaces/primefaces/commit/65795dd9277c59180d88a204884fe64ff747bdf7.

https://github.com/primefaces/primefaces/commit/65795dd9277c59180d88a204884fe64ff747bdf7 removes one probably obsolete line of code for multiselect-mode.

Maybe this issue occurs on http://primefaces.org/showcase/ui/data/datatable/selection.xhtml because `selection="#{dtSelectionView.selectedProduct}"` is set for multiple DataTables. Or .... ???