### PR TITLE
DO NOT MERGE - run integration-tests against Safari

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
     name: Java ${{ matrix.java }}, Profile ${{ matrix.profile }}
     strategy:
       matrix:
-        java: [ 8, 11 ]
-        profile: [ 'headless,firefox,theme-saga,myfaces-2.3.x', 'headless,chrome,theme-saga,myfaces-2.3.x', 'headless,chrome,csp,theme-nova,myfaces-2.3.x', 'headless,chrome,csp,theme-nova,mojarra-2.3.x' ]
+        java: [ 11 ]
+        profile: [ 'headless,safari,theme-saga,myfaces-2.3.x' ]
 
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
Branch to sometimes (e.g. pre-release) run our integration-tests against Safari and check for regressions.

Not part of our regular integration-tests because of stability issues since Safari 14.1
Safari 14.1 (15611.1.21.161.5)
SafariDriver 14.1 (15611.1.21.161.5)
(see https://github.com/primefaces-extensions/primefaces-integration-tests/issues/146 for details)